### PR TITLE
handle nils in map deserialize

### DIFF
--- a/lib/merge_hris_client/deserializer.ex
+++ b/lib/merge_hris_client/deserializer.ex
@@ -20,8 +20,13 @@ defmodule MergeHRISClient.Deserializer do
     |> Map.update!(field, &(Poison.Decode.decode(&1, Keyword.merge(options, [as: struct(mod)]))))
   end
   def deserialize(model, field, :map, mod, options) do
-    model
-    |> Map.update!(field, &(Map.new(&1, fn {key, val} -> {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))} end)))
+    case Map.fetch(model, field) do
+      {:ok, field_val} ->
+        if !is_nil(field_val) do
+          model
+          |> Map.update!(field, &(Map.new(&1, fn {key, val} -> {key, Poison.Decode.decode(val, Keyword.merge(options, [as: struct(mod)]))} end)))
+        end
+    end
   end
   def deserialize(model, field, :date, _, _options) do
     value = Map.get(model, field)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MergeHRISClient.Mixfile do
 
   def project do
     [app: :merge_hris_client,
-     version: "1.0.1",
+     version: "1.0.2",
      elixir: "~> 1.6",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
## Description of the change

As reported by customer, the out-of-the-box auto generated SDK code does not properly handle nil's in the case of map properties. So fix that.

Tested with:

```
  test "deserialize employee" do
    deserialized = Poison.Decoder.decode(%MergeHRISClient.Model.Employee{custom_fields: nil}, [])

    IO.inspect(deserialized)

    deserialized2 = Poison.Decoder.decode(%MergeHRISClient.Model.Employee{custom_fields: %{}}, [])

    IO.inspect(deserialized2)
  end
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> All PRs at Merge must be backed by an Asana ticket.



## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.

